### PR TITLE
fix: fix callback stability for `useSyncExternalStore`

### DIFF
--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -5,15 +5,9 @@ import React from "react";
 
 export function useAsync<T>(options: QueryOptions<T>) {
   const [observer] = React.useState(() => new QueryObserver(options));
-
-  React.useSyncExternalStore(
-    React.useCallback((onStorechange) => observer.subscribe(onStorechange), []),
-    () => observer.getCurrentResult()
-  );
-
+  React.useSyncExternalStore(observer.subscribe, observer.getSnapshot);
   React.useEffect(() => observer.fetch(), []);
-
-  return observer.getCurrentResult();
+  return observer.getSnapshot();
 }
 
 type QueryOptions<T> = {
@@ -74,12 +68,10 @@ class QueryObserver<T> {
     this.listeners.forEach((l) => l());
   }
 
-  subscribe(listener: () => void) {
+  subscribe = (listener: () => void) => {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
-  }
+  };
 
-  getCurrentResult() {
-    return this.result;
-  }
+  getSnapshot = () => this.result;
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -13,7 +13,10 @@ export function useLocalStorage<T>({
   stringify?: (v: T) => string;
 }) {
   React.useSyncExternalStore(
-    (onStoreChange) => localStorageStore.subscribe(key, onStoreChange),
+    React.useCallback(
+      (onStoreChange) => localStorageStore.subscribe(key, onStoreChange),
+      [key]
+    ),
     () => localStorageStore.get(key)
   );
 


### PR DESCRIPTION
Just spotted `subscribe` wasn't stable for `useLocalStorage`.